### PR TITLE
Register authorization handlers for the booking plugin

### DIFF
--- a/plugins/Booking/src/EasyAbp.EShop.Orders.Booking.Application/EasyAbp/EShop/Orders/Booking/EShopOrdersBookingApplicationModule.cs
+++ b/plugins/Booking/src/EasyAbp.EShop.Orders.Booking.Application/EasyAbp/EShop/Orders/Booking/EShopOrdersBookingApplicationModule.cs
@@ -1,5 +1,8 @@
 ﻿using EasyAbp.BookingService;
+using EasyAbp.EShop.Orders.Booking.Authorization;
 using EasyAbp.EShop.Orders.Booking.ObjectExtending;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Modularity;
 
 namespace EasyAbp.EShop.Orders.Booking
@@ -14,6 +17,7 @@ namespace EasyAbp.EShop.Orders.Booking
         public override void PreConfigureServices(ServiceConfigurationContext context)
         {
             EShopOrdersPluginsBookingObjectExtensions.Configure();
+            context.Services.AddSingleton<IAuthorizationHandler, BookingOrderCreationAuthorizationHandler>();
         }
     }
 }

--- a/plugins/Booking/src/EasyAbp.EShop.Payments.Booking.Application/EasyAbp/EShop/Payments/Booking/EShopPaymentsBookingApplicationModule.cs
+++ b/plugins/Booking/src/EasyAbp.EShop.Payments.Booking.Application/EasyAbp/EShop/Payments/Booking/EShopPaymentsBookingApplicationModule.cs
@@ -1,5 +1,8 @@
 ﻿using EasyAbp.BookingService;
+using EasyAbp.EShop.Payments.Booking.Authorization;
 using EasyAbp.EShop.Plugins.Booking;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 using Volo.Abp.Modularity;
 
 namespace EasyAbp.EShop.Payments.Booking
@@ -11,5 +14,9 @@ namespace EasyAbp.EShop.Payments.Booking
     )]
     public class EShopPaymentsBookingApplicationModule : AbpModule
     {
+        public override void PreConfigureServices(ServiceConfigurationContext context)
+        {
+            context.Services.AddSingleton<IAuthorizationHandler, BookingPaymentCreationAuthorizationHandler>();
+        }
     }
 }


### PR DESCRIPTION
BookingOrderCreationAuthorizationHandler is not added to DI by default.
So we think it's better to add it on PreConfigureServices.