### PR TITLE
Persist inventory immediately for the first time invoking

### DIFF
--- a/plugins/Inventories/DaprActors/src/EasyAbp.EShop.Plugins.Inventories.DaprActors/EasyAbp/EShop/Plugins/Inventories/DaprActors/InventoryActor.cs
+++ b/plugins/Inventories/DaprActors/src/EasyAbp.EShop.Plugins.Inventories.DaprActors/EasyAbp/EShop/Plugins/Inventories/DaprActors/InventoryActor.cs
@@ -39,7 +39,7 @@ public class InventoryActor : Actor, IInventoryActor
         }
         else
         {
-            await TryRegisterFlashSalesPersistInventoryTimerAsync();
+            await TryStartIntervalPersistInventoryAsync();
         }
     }
 
@@ -55,11 +55,11 @@ public class InventoryActor : Actor, IInventoryActor
         }
         else
         {
-            await TryRegisterFlashSalesPersistInventoryTimerAsync();
+            await TryStartIntervalPersistInventoryAsync();
         }
     }
 
-    protected virtual async Task TryRegisterFlashSalesPersistInventoryTimerAsync()
+    protected virtual async Task TryStartIntervalPersistInventoryAsync()
     {
         if (FlashSalesInventoryUpdated)
         {
@@ -67,6 +67,8 @@ public class InventoryActor : Actor, IInventoryActor
         }
 
         FlashSalesInventoryUpdated = true;
+
+        await SetInventoryStateAsync(await GetInventoryStateAsync());
 
         await RegisterTimerAsync(null, nameof(TimerSetInventoryStateAsync), null, TimeSpan.FromSeconds(5),
             TimeSpan.FromMilliseconds(-1));

--- a/plugins/Inventories/OrleansGrains/src/EasyAbp.EShop.Plugins.Inventories.OrleansGrains/EasyAbp/EShop/Plugins/Inventories/OrleansGrains/InventoryGrain.cs
+++ b/plugins/Inventories/OrleansGrains/src/EasyAbp.EShop.Plugins.Inventories.OrleansGrains/EasyAbp/EShop/Plugins/Inventories/OrleansGrains/InventoryGrain.cs
@@ -25,7 +25,7 @@ public class InventoryGrain : Grain<InventoryStateModel>, IInventoryGrain
         }
         else
         {
-            TryRegisterFlashSalesPersistInventoryTimer();
+            await TryStartIntervalPersistInventoryAsync();
         }
     }
 
@@ -39,11 +39,11 @@ public class InventoryGrain : Grain<InventoryStateModel>, IInventoryGrain
         }
         else
         {
-            TryRegisterFlashSalesPersistInventoryTimer();
+            await TryStartIntervalPersistInventoryAsync();
         }
     }
 
-    protected virtual void TryRegisterFlashSalesPersistInventoryTimer()
+    protected virtual async Task TryStartIntervalPersistInventoryAsync()
     {
         if (FlashSalesInventoryUpdated)
         {
@@ -51,6 +51,8 @@ public class InventoryGrain : Grain<InventoryStateModel>, IInventoryGrain
         }
 
         FlashSalesInventoryUpdated = true;
+
+        await WriteStateAsync();
 
         RegisterTimer(TimerWriteInventoryStateAsync, new object(), TimeSpan.FromSeconds(5),
             TimeSpan.FromMilliseconds(-1));


### PR DESCRIPTION
This change could reduce the probability that the persistence provider is unavailable, but the inventory successfully changed.